### PR TITLE
可以考虑支持一下上传错误中断

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ class WebpackAliyunOss {
 
 			if (files.length) {
                 const ret = await this.upload(files, true, outputPath);
-                if(ret.errorMsg) {
+                if(ret && ret.errorMsg) {
                     compilation.errors.push(new Error(ret.errorMsg));
                 }
                 return Promise.resolve();
@@ -87,7 +87,7 @@ class WebpackAliyunOss {
 
 		if (files.length) {
             const ret = await this.upload(files);
-            if(ret.errorMsg) {
+            if(ret && ret.errorMsg) {
                 return Promise.reject(new Error(ret.errorMsg));
             } else {
                 return Promise.resolve();

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "webpack-aliyun-oss",
+  "name": "@hetao/webpack-aliyun-oss",
   "version": "0.3.1",
   "main": "index.js",
   "author": "paul",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gp5251/webpack-aliyun-oss.git"
+    "url": "git+https://github.com/gp5251/webpack-aliyun-oss.git"
   },
   "license": "MIT",
   "homepage": "https://github.com/gp5251/webpack-aliyun-oss",
@@ -39,5 +39,8 @@
     "fs-extra": "^8.1.0",
     "jest": "^24.9.0",
     "webpack": "^4.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/gp5251/webpack-aliyun-oss/issues"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hetao/webpack-aliyun-oss",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "index.js",
   "author": "paul",
   "description": "a webpack(>=4) plugin to upload assets to aliyun oss, can be used with or without webpack.",


### PR DESCRIPTION
目前的实现是增加了bail参数，默认是false。
主要是把上传函数中try-catch的异常给处理一下。

我这边因为已经发布到内部的npmjs仓库了，所以对package.json有所修改。